### PR TITLE
Fix `ISwaggerSchema.IOneOf` type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/openai-function-schema",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenAI LLM function schema from OpenAPI (Swagger) document",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/structures/ISwaggerSchema.ts
+++ b/src/structures/ISwaggerSchema.ts
@@ -120,9 +120,12 @@ export namespace ISwaggerSchema {
    * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly
    * converts it to `oneOf` type.
    */
-  export interface IOneOf
-    extends OpenApi.IJsonSchema.IOneOf<ISwaggerSchema>,
-      __IPlugin {}
+  export interface IOneOf extends OpenApi.IJsonSchema.__IAttribute, __IPlugin {
+    /**
+     * List of the union types.
+     */
+    oneOf: Exclude<ISwaggerSchema, ISwaggerSchema.IOneOf>[];
+  }
 
   /**
    * Null type.


### PR DESCRIPTION
Due to infinite bug from TypeScript compiler, made `ISwaggerSchema` type lighter by chaning `ISwaggerSchema.IOneOf` type manually, instead of utilizing its `OpenApi.IJsonSchema.IOneOf<Schema>` argument.