### PR TITLE
Remove `oneOf.discriminator` property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/openai-function-schema",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenAI LLM function schema from OpenAPI (Swagger) document",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,16 +37,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@nestia/fetcher": "^3.4.1",
-    "@samchon/openapi": "^0.3.0",
+    "@nestia/fetcher": "^3.5.0",
+    "@samchon/openapi": "^0.3.1",
     "commander": "^10.0.0",
     "inquirer": "^8.2.5",
-    "typia": "^6.4.0"
+    "typia": "^6.4.3"
   },
   "devDependencies": {
-    "@nestia/core": "^3.4.1",
+    "@nestia/core": "^3.5.0",
     "@nestia/e2e": "^0.6.0",
-    "@nestia/sdk": "^3.4.1",
+    "@nestia/sdk": "^3.5.0",
     "@nestjs/common": "^10.3.10",
     "@nestjs/core": "^10.3.10",
     "@nestjs/platform-express": "^10.3.10",

--- a/test/features/composer/test_composer_schema_oneof.ts
+++ b/test/features/composer/test_composer_schema_oneof.ts
@@ -1,0 +1,79 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import { IOpenAiSchema, OpenAiComposer } from "@wrtnio/openai-function-schema";
+import typia, { IJsonApplication } from "typia";
+
+export const test_composer_schema_oneof = (): void => {
+  const app: IJsonApplication =
+    typia.json.application<[Circle | Triangle | Rectangle]>();
+  const schema: OpenApi.IJsonSchema = app.schemas[0];
+  const casted: IOpenAiSchema | null = OpenAiComposer.schema(
+    app.components,
+    schema,
+  );
+  TestValidator.equals("oneOf")(casted)({
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["circle"],
+          },
+          radius: {
+            type: "number",
+          },
+        },
+        required: ["type", "radius"],
+      },
+      {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["triangle"],
+          },
+          base: {
+            type: "number",
+          },
+          height: {
+            type: "number",
+          },
+        },
+        required: ["type", "base", "height"],
+      },
+      {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["square"],
+          },
+          width: {
+            type: "number",
+          },
+          height: {
+            type: "number",
+          },
+        },
+        required: ["type", "width", "height"],
+      },
+    ],
+    ...{ discriminator: undefined },
+  });
+};
+
+interface Circle {
+  type: "circle";
+  radius: number;
+}
+interface Triangle {
+  type: "triangle";
+  base: number;
+  height: number;
+}
+interface Rectangle {
+  type: "square";
+  width: number;
+  height: number;
+}


### PR DESCRIPTION
It is because `oneOf.discriminator` is the property only for the every `oneOf` types are `$ref`.