### PR TITLE
Adjust samchon/openapi#40 update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/openai-function-schema",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "OpenAI LLM function schema from OpenAPI (Swagger) document",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,11 +37,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@nestia/fetcher": "^3.10.0",
-    "@samchon/openapi": "^0.4.3",
+    "@nestia/fetcher": "^3.11.1",
+    "@samchon/openapi": "^0.4.6",
     "commander": "^10.0.0",
     "inquirer": "^8.2.5",
-    "typia": "^6.7.2"
+    "typia": "^6.8.0"
   },
   "devDependencies": {
     "@nestia/core": "^3.10.0",

--- a/src/structures/IOpenAiFunction.ts
+++ b/src/structures/IOpenAiFunction.ts
@@ -77,6 +77,33 @@ export interface IOpenAiFunction {
 
   /**
    * List of parameter schemas.
+   *
+   * If you've configured {@link IOpenAiDocument.IOptions.keyword} (as `true`),
+   * number of {@link IOpenAiFunction.parameters} are always 1 and the first parameter's
+   * type is always {@link IOpenAiSchema.IObject}. The properties' rule is:
+   *
+   * - `pathParameters`: Path parameters of {@link IMigrateRoute.parameters}
+   * - `query`: Query parameter of {@link IMigrateRoute.query}
+   * - `body`: Body parameter of {@link IMigrateRoute.body}
+   *
+   * ```typescript
+   * {
+   *   ...pathParameters,
+   *   query,
+   *   body,
+   * }
+   * ```
+   *
+   * Otherwise, the parameters would be multiple, and the sequence of the parameters
+   * are following below rules:
+   *
+   * ```typescript
+   * [
+   *   ...pathParameters,
+   *   ...(query ? [query] : []),
+   *   ...(body ? [body] : []),
+   * ]
+   * ```
    */
   parameters: IOpenAiSchema[];
 


### PR DESCRIPTION
In the JSON schema definition, it is nonsensible to inserting null value to enum property array.

However, Github OpenAPI document is actually doing the crazy thing.

This PR supports it by allowing the null value to the enum proeprty array.